### PR TITLE
Integrate type inference.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 
 **/*.pyc
 
+type_inference/annotation-tools/
+type_inference/checker-framework-inference/
+type_inference/checker-framework/
+type_inference/dataflowexample
+type_inference/generic-type-inference-solver/
+type_inference/jsr308-langtools/
+

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo "Type Inference"
+cd type_inference
+./run.sh
+cd ..
 
 echo "Dynamic Analysis"
 cd dynamic_analysis

--- a/type_inference/run.sh
+++ b/type_inference/run.sh
@@ -2,23 +2,19 @@
 
 CORPUS_DIR=../corpus/benchmarks
 
-if [ ! -d "checker-framework-inference" ]; then
-  echo "Downloading checker-framework"
-  git clone https://github.com/typetools/checker-framework-inference.git
-  cd checker-framework-inference
-  echo "Checking out fixed commit for reproducability."
-  git checkout c6692c7c6ae0d6dfc785257d2468c3a2908f39e0
-  export TRAVIS_BUILD_DIR=./
-  ./.travis-build.sh
-  cd ..
+if [ -d "generic-type-inference-solver" ]; then
+  (cd generic-type-inference-solver && git pull)
+else
+  git clone https://github.com/wmdietl/generic-type-inference-solver.git
 fi
 
-cd checker-framework-inference
-export TRAVIS_BUILD_DIR=./
+cd generic-type-inference-solver
+export TRAVIS_BUILD_DIR=`pwd`
+
 ./.travis-build.sh
 cd ..
 
 
 echo "Apply checker-framework-inference"
-#TODO: change prog2dfg to petablox
+
 


### PR DESCRIPTION
First step to integrate type inference into integration.
The whole tool-chain should be built as result.
If the default JAVA_HOME in
https://github.com/wmdietl/generic-type-inference-solver/blob/master/.travis-build-without-test.sh
doesn't work in this setup, we can move to run.sh and use a different value.
I'll next work on running on the corpus of sorted examples.
