### PR TITLE
infer sequence type for examples in corpus, update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,7 @@ type_inference/checker-framework/
 type_inference/dataflowexample
 type_inference/generic-type-inference-solver/
 type_inference/jsr308-langtools/
-
+type_inference/do-like-javac/
+corpus/annotated/
+corpus/**/logs/
+**/*.jaif

--- a/type_inference/run.sh
+++ b/type_inference/run.sh
@@ -2,8 +2,7 @@
 CORPUS_DIR=../../corpus
 SCRIPT=$(readlink -f $0)
 MYDIRPATH=`dirname $SCRIPT`
-#DLJC=$MYDIRPATH/do-like-javac
-DLJC_BIN=$MYDIRPATH/pascali-public/do-like-javac/bin
+DLJC=$MYDIRPATH/do-like-javac
 
 if [ -d "generic-type-inference-solver" ]; then
   (cd generic-type-inference-solver && git pull)
@@ -11,29 +10,28 @@ else
   git clone https://github.com/Jianchu/generic-type-inference-solver.git
 fi
 
-#if [ -d "do-like-javac" ]; then
-if [ -d "pascali-public" ]; then
-  (cd do-like-javac && git pull)
+if [ -d "do-like-javac" ]; then
+  (cd do-like-javac && git pull && git checkout checker)
 else
-  #git clone https://github.com/SRI-CSL/do-like-javac.git
-  git clone https://github.com/Jianchu/pascali-public.git
+  git clone https://github.com/SRI-CSL/do-like-javac.git
+  (cd do-like-javac && git checkout checker)
 fi
 
 cd generic-type-inference-solver
 export TRAVIS_BUILD_DIR=`pwd`
 
 ./.travis-build-without-test.sh
-
+rm -rf $CORPUS_DIR/annotated/
 for f in $CORPUS_DIR/*
 do
   if [ -d "$f" ]; then
-  	cd $f
-  	ant clean
-  	echo "Inferring ${PWD##*/}:"
-    python $DLJC_BIN/do-like-javac.py -t inference --solverArgs="backEndType=maxsatbackend.MaxSat" --checker ontology.OntologyChecker --solver constraintsolver.ConstraintSolver -o logs -m ROUNDTRIP -afud $CORPUS_DIR/annotated -- ant
+    cd $f
+    ant clean
+    echo "Inferring ${PWD##*/}:"
+    python $DLJC/dljc -t inference --solverArgs="backEndType=maxsatbackend.MaxSat" --checker ontology.OntologyChecker --solver constraintsolver.ConstraintSolver -o logs -m ROUNDTRIP -afud $CORPUS_DIR/annotated -- ant
   fi
 done
 
-# Sort03 causes checker framework inference crushing, 
+# Sort03 causes checker framework inference crushing,
 # the problem has been filed as Issue #24 in checker framework inference.
 cd ..

--- a/type_inference/run.sh
+++ b/type_inference/run.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-
-CORPUS_DIR=../../corpus/benchmarks
-CORPUS_SORT1_SRC_DIR=../../corpus/sorting/00_sort/Sort01/src
-CORPUS_SORT2_SRC_DIR=../../corpus/sorting/00_sort/Sort02/src
-CORPUS_SORT3_SRC_DIR=../../corpus/sorting/00_sort/Sort03/src
+CORPUS_DIR=../../corpus
+SCRIPT=$(readlink -f $0)
+MYDIRPATH=`dirname $SCRIPT`
+#DLJC=$MYDIRPATH/do-like-javac
+DLJC_BIN=$MYDIRPATH/pascali-public/do-like-javac/bin
 
 if [ -d "generic-type-inference-solver" ]; then
   (cd generic-type-inference-solver && git pull)
@@ -11,18 +11,29 @@ else
   git clone https://github.com/Jianchu/generic-type-inference-solver.git
 fi
 
+#if [ -d "do-like-javac" ]; then
+if [ -d "pascali-public" ]; then
+  (cd do-like-javac && git pull)
+else
+  #git clone https://github.com/SRI-CSL/do-like-javac.git
+  git clone https://github.com/Jianchu/pascali-public.git
+fi
+
 cd generic-type-inference-solver
 export TRAVIS_BUILD_DIR=`pwd`
 
 ./.travis-build-without-test.sh
 
-echo "Inferring example Sort01"
-bash scripts/ontology/roundtripOntologyMaxSat.sh $CORPUS_SORT1_SRC_DIR/*.java
-echo "Inferring example Sort02"
-bash scripts/ontology/roundtripOntologyMaxSat.sh $CORPUS_SORT2_SRC_DIR/*.java
-# Following example causes checker framework inference crushing, 
-# the problem has been filed as Issue #24 in checker framework inference.
+for f in $CORPUS_DIR/*
+do
+  if [ -d "$f" ]; then
+  	cd $f
+  	ant clean
+  	echo "Inferring ${PWD##*/}:"
+    python $DLJC_BIN/do-like-javac.py -t inference --solverArgs="backEndType=maxsatbackend.MaxSat" --checker ontology.OntologyChecker --solver constraintsolver.ConstraintSolver -o logs -m ROUNDTRIP -afud $CORPUS_DIR/annotated -- ant
+  fi
+done
 
-# echo "Inferring example Sort03"
-# bash scripts/ontology/roundtripOntologyMaxSat.sh $CORPUS_SORT3_SRC_DIR/*.java
+# Sort03 causes checker framework inference crushing, 
+# the problem has been filed as Issue #24 in checker framework inference.
 cd ..


### PR DESCRIPTION
Inference tool infers sequence for each directories in "corpus", the output annotated files are put in corpus/annotated.
